### PR TITLE
Agregando Diseño responsivo sección 3°

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -923,6 +923,70 @@ margin-left: 10px;
 width: 350px;
 }
 
+.testimonials {
+    padding: 60px 0;
+  }
+
+  .testimonial_header h1 {
+    font-size: 26px;
+    margin-top: 40px;
+  }
+
+  .testimonial_header p {
+    font-size: 13px;
+    margin: 0 20px 40px;
+    line-height: 1.5;
+  }
+
+  .testimonials_wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    max-width: 92%;
+    margin: 0 auto;
+    gap: 40px;
+  }
+
+  .testimonial {
+    width: 100%;
+    height: auto;
+    margin: 0 auto;
+  }
+
+  .testimonial_content {
+    padding: 25px 20px;
+  }
+
+  .testimonial_content p {
+    font-size: 13px;
+    line-height: 1.6;
+    width: 100%;
+    height: auto;
+    text-align: center;
+  }
+
+  .quote {
+    font-size: 60px;
+    top: -15px;
+    left: 15px;
+  }
+
+  .client {
+    justify-content: center;
+    margin: 10px auto 0;
+    gap: 10px;
+  }
+
+  .client h1 {
+    font-size: 15px;
+  }
+
+  .client img {
+    width: 45px;
+    height: 45px;
+  }
+
+
 .work-section{
 padding: 50px;
 margin-top: 250px;
@@ -1239,6 +1303,43 @@ position: absolute;
 position: absolute;
 }
 
+.testimonials {
+    padding: 80px 0;
+  }
+
+  .testimonials_wrapper {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 50px;
+    max-width: 85%;
+    margin: 0 auto;
+  }
+
+  .testimonial {
+    width: 100%;
+    height: auto;
+    margin: 0 auto;
+  }
+
+  .testimonial_content {
+    padding: 35px 25px;
+  }
+
+  .testimonial_content p {
+    font-size: 14px;
+    line-height: 1.7;
+    width: 100%;
+  }
+
+  .quote {
+    font-size: 80px;
+    left: 20px;
+  }
+
+  .client {
+    margin-left: 20px;
+  }
+
 .contact-container {
     max-width: 80%;
     padding: 24px;
@@ -1388,6 +1489,40 @@ position: absolute;
 .card-content2 h1{
 position: absolute;
 }
+
+.testimonials {
+    padding: 100px 0;
+  }
+
+  .testimonials_wrapper {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 50px;
+    max-width: 90%;
+    margin: 0 auto;
+  }
+
+  .testimonial {
+    width: 100%;
+    height: auto;
+  }
+
+  .testimonial_content {
+    padding: 40px 30px;
+  }
+
+  .testimonial_content p {
+    font-size: 14px;
+    line-height: 1.6;
+  }
+
+  .quote {
+    font-size: 90px;
+    left: 25px;
+  }
+
+  .client {
+    margin-left: 25px;
+  }
 
 .contact-container {
     max-width: 70%;


### PR DESCRIPTION
Fixes #15 
Se creó diseño responsivo correspondiente a la sección 3°, para su adaptación a diferentes dispositivos.

iPad Pro:
<img width="601" height="519" alt="image" src="https://github.com/user-attachments/assets/3bc33f96-bdc8-4591-acbc-73b7e675d235" />

iPad Mini:
<img width="476" height="636" alt="image" src="https://github.com/user-attachments/assets/2e4aa924-f989-4d5d-bcd8-37580f275114" />

Dispositivos móviles:
<img width="359" height="802" alt="image" src="https://github.com/user-attachments/assets/d1d33fff-e453-4cd4-98ce-7f364e34419c" />

Listo para revisión y fusión.